### PR TITLE
Basic GET/DNS handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@adobe/helix-shared-process-queue": "3.0.1",
         "@adobe/helix-shared-wrap": "2.0.1",
         "@adobe/helix-status": "10.0.11",
-        "@adobe/helix-universal-logger": "3.0.13"
+        "@adobe/helix-universal-logger": "^3.0.13"
       },
       "devDependencies": {
         "@adobe/eslint-config-helix": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "start": "nodemon",
-    "test": "c8 mocha  -i -g 'Post-Deploy'",
+    "test": "c8 --reporter=text --reporter=lcov mocha  -i -g 'Post-Deploy'",
     "test-postdeploy": "mocha -g 'Post-Deploy'",
     "lint": "eslint .",
     "semantic-release": "semantic-release",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@adobe/helix-shared-process-queue": "3.0.1",
     "@adobe/helix-shared-wrap": "2.0.1",
     "@adobe/helix-status": "10.0.11",
-    "@adobe/helix-universal-logger": "3.0.13"
+    "@adobe/helix-universal-logger": "^3.0.13"
   },
   "devDependencies": {
     "@adobe/eslint-config-helix": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "wsk": {
     "nodeVersion": 18,
     "target": "aws",
-    "name": "helix3/certificate-provider@${version}",
+    "name": "helix-services/certificate-provider@${version}",
     "testUrl": "/_status_check/healthcheck.json",
     "memory": 256,
     "fastlyServiceId!important": ""

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "name": "helix3/certificate-provider@${version}",
     "testUrl": "/_status_check/healthcheck.json",
     "memory": 256,
-    "fastlyServiceId!important": "",
-    "awsRole!important": "arn:aws:iam::118435662149:role/helix-service-role-pipeline"
+    "fastlyServiceId!important": ""
   },
   "mocha": {
     "spec": "test/**/*.test.js",

--- a/src/dns.js
+++ b/src/dns.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { resolveCname, resolve4 } from 'dns';
+import { promisify } from 'util';
+
+const dnsresolvers = {
+  CNAME: promisify(resolveCname),
+  A: promisify(resolve4),
+};
+export async function validateRecords(domain, records) {
+  const results = await Promise.all(
+    Object.entries(records).map(async ([type, value]) => {
+      const resolver = dnsresolvers[type];
+      if (!resolver) {
+        throw new Error(`Unsupported record type ${type}`);
+      }
+      const resolvedRecords = await resolver(domain);
+      if (resolvedRecords.length === 0) {
+        return { errors: `No ${type} records found for ${domain}` };
+      }
+      const expected = Array.isArray(value) ? value : [value];
+      const unexpected = resolvedRecords.filter((record) => !expected.includes(record));
+      const missing = expected.filter((record) => !resolvedRecords.includes(record));
+      const errors = [
+        ...unexpected.map((record) => `Unexpected ${type} record ${record} for ${domain}`),
+        ...missing.map((record) => `Missing ${type} record ${record} for ${domain}`),
+      ];
+      return { errors };
+    }),
+  );
+  // merge results
+  const allerrors = results.reduce((acc, { errors }) => [...acc, ...errors], []);
+  if (allerrors.length > 0) {
+    const consolidatedError = new Error(`DNS validation failed: ${allerrors[0]}${allerrors.length > 1 ? ` and ${allerrors.length - 1} more errors` : ''}`);
+    consolidatedError.errors = allerrors;
+    throw consolidatedError;
+  }
+  return true;
+}

--- a/src/dns.js
+++ b/src/dns.js
@@ -40,7 +40,7 @@ export async function validateRecords(domain, records) {
   // merge results
   const allerrors = results.reduce((acc, { errors }) => [...acc, ...errors], []);
   if (allerrors.length > 0) {
-    const consolidatedError = new Error(`DNS validation failed: ${allerrors[0]}${allerrors.length > 1 ? ` and ${allerrors.length - 1} more errors` : ''}`);
+    const consolidatedError = new Error(`DNS validation failed: ${allerrors[0]} and ${allerrors.length - 1} more errors`);
     consolidatedError.errors = allerrors;
     throw consolidatedError;
   }

--- a/src/dns.js
+++ b/src/dns.js
@@ -23,9 +23,13 @@ export async function validateRecords(domain, records) {
       if (!resolver) {
         throw new Error(`Unsupported record type ${type}`);
       }
-      const resolvedRecords = await resolver(domain);
-      if (resolvedRecords.length === 0) {
-        return { errors: `No ${type} records found for ${domain}` };
+      let resolvedRecords = [];
+      try {
+        resolvedRecords = await resolver(domain);
+      } catch (e) {
+        if (e.code !== 'ENODATA') {
+          return { errors: `No ${type} records found for ${domain}` };
+        }
       }
       const expected = Array.isArray(value) ? value : [value];
       const unexpected = resolvedRecords.filter((record) => !expected.includes(record));

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -10,16 +10,13 @@
  * governing permissions and limitations under the License.
  */
 import { Response } from '@adobe/fetch';
+import { isAcmeChallenge, isApexDomain, makeResponse } from './utils.js';
 
 export async function createDomain(domain, request, context) {
-  const { logger } = context;
-  logger.info('Not doing anything', domain);
   return new Response('Not yet implemented', { status: 201 });
 }
 
 export async function issueCertificate(domain, request, context) {
-  const { logger } = context;
-  logger.info('Not doing anything', domain);
   return new Response('Check status here', {
     status: 301,
     headers: { Location: `/domains/${domain}` },
@@ -27,7 +24,29 @@ export async function issueCertificate(domain, request, context) {
 }
 
 export async function getDomainDetails(domain, request, context, contentType) {
-  const { logger } = context;
-  logger.info('Not doing anything', domain, contentType);
-  return new Response('Not yet implemented', { status: 200 });
+  if (isAcmeChallenge(domain)) {
+    const CNAME = `${domain.replace('_acme-challenge.', '').replace(/\./g, '-')}.aemvalidations.net`;
+    const json = {
+      records: {
+        CNAME,
+      },
+    };
+    return makeResponse(json, contentType);
+  }
+  if (await isApexDomain(domain)) {
+    console.log('apex domain', domain);
+    const json = {
+      records: {
+        A: ['151.101.194.117', '151.101.66.117', '151.101.2.117', '151.101.130.117'],
+      },
+    };
+    return makeResponse(json, contentType);
+  } else {
+    const json = {
+      records: {
+        CNAME: 'cdn.aem.live',
+      },
+    };
+    return makeResponse(json, contentType);
+  }
 }

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { Response } from '@adobe/fetch';
+
+export async function createDomain(domain, request, context) {
+  const { logger } = context;
+  logger.info('Not doing anything', domain);
+  return new Response('Not yet implemented', { status: 201 });
+}
+
+export async function issueCertificate(domain, request, context) {
+  const { logger } = context;
+  logger.info('Not doing anything', domain);
+  return new Response('Check status here', {
+    status: 301,
+    headers: { Location: `/domains/${domain}` },
+  });
+}
+
+export async function getDomainDetails(domain, request, context, contentType) {
+  const { logger } = context;
+  logger.info('Not doing anything', domain, contentType);
+  return new Response('Not yet implemented', { status: 200 });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -25,10 +25,10 @@ function run(request, context) {
   const { logger } = context;
   const url = new URL(request.url);
   const { pathname } = url;
-  const [prefix, domain] = pathname.split('/');
+  const [_, prefix, domain] = pathname.split('/');
   const contentType = (request.headers.get('content-type') || 'text/plain') === 'application/json' ? 'json' : 'text';
   if (prefix !== 'domains') {
-    return new Response('This is not the service you\'ve been looking for', { status: 404 });
+    return new Response(`This is not the ${prefix} service you've been looking for`, { status: 404 });
   }
   if (request.method === 'POST' && !domain) {
     return createDomain(domain, request, context, contentType);

--- a/src/index.js
+++ b/src/index.js
@@ -28,9 +28,7 @@ function run(request, context) {
   if (parts.indexOf('domain') === -1) {
     return new Response('This is not the service you\'ve been looking for', { status: 404 });
   }
-  const [prefix, domain] = parts.slice(parts.indexOf('domain'));
-  console.log('domain', domain);
-  console.log('prefix', prefix);
+  const [_, domain] = parts.slice(parts.indexOf('domain'));
 
   const contentType = (request.headers.get('content-type') || 'text/plain') === 'application/json' ? 'json' : 'text';
   if (request.method === 'POST' && !domain) {
@@ -42,7 +40,6 @@ function run(request, context) {
   if (request.method === 'GET' && domain) {
     return getDomainDetails(domain, request, context, contentType);
   }
-  console.error('Unsupported request', request.method, request.url);
   return new Response('Unsupported request', { status: 400 });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 import wrap from '@adobe/helix-shared-wrap';
-import { logger as unilogger } from '@adobe/helix-universal-logger';
 import { helixStatus } from '@adobe/helix-status';
+import { logger } from '@adobe/helix-universal-logger';
 import { Response } from '@adobe/fetch';
 import { createDomain, issueCertificate, getDomainDetails } from './handlers.js';
 
@@ -22,7 +22,7 @@ import { createDomain, issueCertificate, getDomainDetails } from './handlers.js'
  * @returns {Response} a response
  */
 function run(request, context) {
-  const { logger } = context;
+  const { logger: log } = context;
   const url = new URL(request.url);
   const { pathname } = url;
   // pathname is /helix-services/certificate-provider/ci7641176065/domain/example.com
@@ -31,8 +31,8 @@ function run(request, context) {
     return new Response('This is not the service you\'ve been looking for', { status: 404 });
   }
   const [prefix, domain] = parts.slice(parts.indexOf('domain'));
-  logger.info('domain', domain);
-  logger.info('prefix', prefix);
+  log.log('domain', domain);
+  log.log('prefix', prefix);
 
   const contentType = (request.headers.get('content-type') || 'text/plain') === 'application/json' ? 'json' : 'text';
   if (request.method === 'POST' && !domain) {
@@ -44,11 +44,11 @@ function run(request, context) {
   if (request.method === 'GET' && domain) {
     return getDomainDetails(domain, request, context, contentType);
   }
-  logger.error('Unsupported request', request.method, request.url);
+  log.error('Unsupported request', request.method, request.url);
   return new Response('Unsupported request', { status: 400 });
 }
 
 export const main = wrap(run)
   .with(helixStatus)
-  .with(unilogger.trace)
-  .with(unilogger);
+  .with(logger.trace)
+  .with(logger);

--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,16 @@ function run(request, context) {
   const { logger } = context;
   const url = new URL(request.url);
   const { pathname } = url;
-  const [_, prefix, domain] = pathname.split('/');
-  const contentType = (request.headers.get('content-type') || 'text/plain') === 'application/json' ? 'json' : 'text';
-  if (prefix !== 'domains') {
-    return new Response(`This is not the ${prefix} service you've been looking for`, { status: 404 });
+  // pathname is /helix-services/certificate-provider/ci7641176065/domain/example.com
+  const parts = pathname.split('/').filter((p) => p.length > 0);
+  if (parts.indexOf('domain') === -1) {
+    return new Response('This is not the service you\'ve been looking for', { status: 404 });
   }
+  const [prefix, domain] = parts.slice(parts.indexOf('domain'));
+  logger.info('domain', domain);
+  logger.info('prefix', prefix);
+
+  const contentType = (request.headers.get('content-type') || 'text/plain') === 'application/json' ? 'json' : 'text';
   if (request.method === 'POST' && !domain) {
     return createDomain(domain, request, context, contentType);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@
  */
 import wrap from '@adobe/helix-shared-wrap';
 import { helixStatus } from '@adobe/helix-status';
-import { logger } from '@adobe/helix-universal-logger';
 import { Response } from '@adobe/fetch';
 import { createDomain, issueCertificate, getDomainDetails } from './handlers.js';
 
@@ -22,7 +21,6 @@ import { createDomain, issueCertificate, getDomainDetails } from './handlers.js'
  * @returns {Response} a response
  */
 function run(request, context) {
-  const { logger: log } = context;
   const url = new URL(request.url);
   const { pathname } = url;
   // pathname is /helix-services/certificate-provider/ci7641176065/domain/example.com
@@ -31,8 +29,8 @@ function run(request, context) {
     return new Response('This is not the service you\'ve been looking for', { status: 404 });
   }
   const [prefix, domain] = parts.slice(parts.indexOf('domain'));
-  log.log('domain', domain);
-  log.log('prefix', prefix);
+  console.log('domain', domain);
+  console.log('prefix', prefix);
 
   const contentType = (request.headers.get('content-type') || 'text/plain') === 'application/json' ? 'json' : 'text';
   if (request.method === 'POST' && !domain) {
@@ -44,11 +42,9 @@ function run(request, context) {
   if (request.method === 'GET' && domain) {
     return getDomainDetails(domain, request, context, contentType);
   }
-  log.error('Unsupported request', request.method, request.url);
+  console.error('Unsupported request', request.method, request.url);
   return new Response('Unsupported request', { status: 400 });
 }
 
 export const main = wrap(run)
-  .with(helixStatus)
-  .with(logger.trace)
-  .with(logger);
+  .with(helixStatus);

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import wrap from '@adobe/helix-shared-wrap';
 import { logger as unilogger } from '@adobe/helix-universal-logger';
 import { helixStatus } from '@adobe/helix-status';
 import { Response } from '@adobe/fetch';
-import { createDomain, issueCertificate, getDomainDetails } from './handlers';
+import { createDomain, issueCertificate, getDomainDetails } from './handlers.js';
 
 /**
  * This is the main function

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export async function isApexDomain(domain) {
+  // this is stupid and wrong, but good for now
+  // better: fetch https://publicsuffix.org/list/public_suffix_list.dat
+  return domain.split('.').length === 2;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,8 +9,33 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { Response } from '@adobe/fetch';
+
 export async function isApexDomain(domain) {
   // this is stupid and wrong, but good for now
   // better: fetch https://publicsuffix.org/list/public_suffix_list.dat
-  return domain.split('.').length === 2;
+  return (domain.split('.').length) === 2;
+}
+
+export function isAcmeChallenge(domain) {
+  return domain.split('.')[0] === '_acme-challenge';
+}
+
+export function makeResponse(json, type, status = 200) {
+  if (type === 'json') {
+    return new Response(JSON.stringify(json), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  return new Response(Object
+    .entries(json.records)
+    .reduce(
+      (acc, [key, value]) => `${acc}
+${key}: ${Array.isArray(value) ? value.join(`\n${key}: `) : value}\n`,
+      'Please create following DNS records: ',
+    ), {
+    status,
+    headers: { 'Content-Type': 'text/plain' },
+  });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,11 +21,17 @@ export function isAcmeChallenge(domain) {
   return domain.split('.')[0] === '_acme-challenge';
 }
 
-export function makeResponse(json, type, status = 200) {
+export function makeResponse(json, type, status = 200, dnserrors = []) {
+  const headers = {
+    'Content-Type': type === 'json' ? 'application/json' : 'text/plain',
+  };
+  if (dnserrors.length > 0) {
+    [headers['X-Error']] = dnserrors;
+  }
   if (type === 'json') {
-    return new Response(JSON.stringify(json), {
+    return new Response(JSON.stringify({ ...json, errors: dnserrors }), {
       status,
-      headers: { 'Content-Type': 'application/json' },
+      headers,
     });
   }
   return new Response(Object
@@ -36,6 +42,6 @@ ${key}: ${Array.isArray(value) ? value.join(`\n${key}: `) : value}\n`,
       'Please create following DNS records: ',
     ), {
     status,
-    headers: { 'Content-Type': 'text/plain' },
+    headers,
   });
 }

--- a/test/dns.test.js
+++ b/test/dns.test.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+
+import assert, { fail } from 'assert';
+import { validateRecords } from '../src/dns.js';
+
+describe('DNS Tests', () => {
+  it('validateRecords complains about invalid records', async () => {
+    try {
+      await validateRecords('example.com', { FOO: 'bar' });
+      fail('should have thrown');
+    } catch (e) {
+      assert.strictEqual(e.message, 'Unsupported record type FOO');
+    }
+  });
+
+  it('validateRecords complains about lacking records', async () => {
+    try {
+      await validateRecords('example.com', { CNAME: 'bar' });
+      fail('should have thrown');
+    } catch (e) {
+      assert.strictEqual(e.message, 'DNS validation failed: Missing CNAME record bar for example.com and 0 more errors');
+    }
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -60,6 +60,16 @@ describe('Index Tests', () => {
     assert.ok(text.includes('CNAME: example-com.aemvalidations.net'), text);
   });
 
+  it('index function handles correct acme-challenge domains', async () => {
+    const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/_acme-challenge.aem.page'), {
+      logger: console,
+    });
+    assert.strictEqual(result.status, 200);
+    const text = await result.text();
+    assert.ok(text.includes('Please create following DNS records:'));
+    assert.ok(text.includes('CNAME: aem-page.aemvalidations.net'), text);
+  });
+
   it('index function handles apex as JSON', async () => {
     const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/example.com', {
       headers: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,7 +17,7 @@ import { main } from '../src/index.js';
 
 describe('Index Tests', () => {
   it('index function is present', async () => {
-    const result = await main(new Request('https://localhost/'), {});
-    assert.strictEqual(await result.text(), 'This is not the service you\'ve been looking for');
+    const result = await main(new Request('https://localhost/foo'), {});
+    assert.strictEqual(await result.text(), 'This is not the foo service you\'ve been looking for');
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,4 +29,55 @@ describe('Index Tests', () => {
     });
     assert.strictEqual(result.status, 400);
   });
+
+  it('index function handles non-apex domains', async () => {
+    const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/www.example.com'), {
+      logger: console,
+    });
+    assert.strictEqual(result.status, 200);
+    const text = await result.text();
+    assert.ok(text.includes('Please create following DNS records:'));
+    assert.ok(text.includes('CNAME: cdn.aem.live'), text);
+  });
+
+  it('index function handles apex domains', async () => {
+    const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/example.com'), {
+      logger: console,
+    });
+    assert.strictEqual(result.status, 200);
+    const text = await result.text();
+    assert.ok(text.includes('Please create following DNS records:'));
+    assert.ok(text.includes('A: 151.101.66.117'), text);
+  });
+
+  it('index function handles acme-challenge domains', async () => {
+    const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/_acme-challenge.example.com'), {
+      logger: console,
+    });
+    assert.strictEqual(result.status, 200);
+    const text = await result.text();
+    assert.ok(text.includes('Please create following DNS records:'));
+    assert.ok(text.includes('CNAME: example-com.aemvalidations.net'), text);
+  });
+
+  it('index function handles apex as JSON', async () => {
+    const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/example.com', {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }), {
+      logger: console,
+    });
+    assert.strictEqual(result.status, 200);
+    const json = await result.json();
+    assert.deepStrictEqual(json, {
+      records: {
+        A: [
+          '151.101.194.117',
+          '151.101.66.117',
+          '151.101.2.117',
+          '151.101.130.117'],
+      },
+    });
+  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,7 +34,7 @@ describe('Index Tests', () => {
     const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/www.example.com'), {
       logger: console,
     });
-    assert.strictEqual(result.status, 200);
+    assert.strictEqual(result.status, 202);
     const text = await result.text();
     assert.ok(text.includes('Please create following DNS records:'));
     assert.ok(text.includes('CNAME: cdn.aem.live'), text);
@@ -44,7 +44,7 @@ describe('Index Tests', () => {
     const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/example.com'), {
       logger: console,
     });
-    assert.strictEqual(result.status, 200);
+    assert.strictEqual(result.status, 202);
     const text = await result.text();
     assert.ok(text.includes('Please create following DNS records:'));
     assert.ok(text.includes('A: 151.101.66.117'), text);
@@ -54,7 +54,7 @@ describe('Index Tests', () => {
     const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/_acme-challenge.example.com'), {
       logger: console,
     });
-    assert.strictEqual(result.status, 200);
+    assert.strictEqual(result.status, 202);
     const text = await result.text();
     assert.ok(text.includes('Please create following DNS records:'));
     assert.ok(text.includes('CNAME: example-com.aemvalidations.net'), text);
@@ -68,7 +68,7 @@ describe('Index Tests', () => {
     }), {
       logger: console,
     });
-    assert.strictEqual(result.status, 200);
+    assert.strictEqual(result.status, 202);
     const json = await result.json();
     assert.deepStrictEqual(json, {
       records: {
@@ -78,6 +78,13 @@ describe('Index Tests', () => {
           '151.101.2.117',
           '151.101.130.117'],
       },
+      errors: [
+        'Unexpected A record 93.184.216.34 for example.com',
+        'Missing A record 151.101.194.117 for example.com',
+        'Missing A record 151.101.66.117 for example.com',
+        'Missing A record 151.101.2.117 for example.com',
+        'Missing A record 151.101.130.117 for example.com',
+      ],
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,8 +16,17 @@ import { Request } from '@adobe/fetch';
 import { main } from '../src/index.js';
 
 describe('Index Tests', () => {
-  it('index function is present', async () => {
-    const result = await main(new Request('https://localhost/foo'), {});
-    assert.strictEqual(await result.text(), 'This is not the foo service you\'ve been looking for');
+  it('index function rejects wrong prefix', async () => {
+    const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/foo'), {
+      logger: console,
+    });
+    assert.strictEqual(await result.text(), 'This is not the service you\'ve been looking for');
+  });
+
+  it('index function rejects wrong requests', async () => {
+    const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain'), {
+      logger: console,
+    });
+    assert.strictEqual(result.status, 400);
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,6 +18,6 @@ import { main } from '../src/index.js';
 describe('Index Tests', () => {
   it('index function is present', async () => {
     const result = await main(new Request('https://localhost/'), {});
-    assert.strictEqual(await result.text(), 'Hello, world.');
+    assert.strictEqual(await result.text(), 'This is not the service you\'ve been looking for');
   });
 });

--- a/test/post-deploy-utils.js
+++ b/test/post-deploy-utils.js
@@ -21,7 +21,7 @@ export class OpenwhiskTarget {
     Object.assign(this, {
       namespace: 'helix',
       package: 'helix-services',
-      name: packjson.name.replace('@adobe/franklin-', ''),
+      name: packjson.name.replace('@adobe/aem-', ''),
       version: String(packjson.version),
     }, opts);
     if (process.env.CI && process.env.CIRCLE_BUILD_NUM && process.env.CIRCLE_BRANCH !== 'main' && !opts.version) {

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -26,6 +26,7 @@ createTargets().forEach((target) => {
 
     it('index function rejects wrong prefix', async () => {
       const url = target.url('/foo');
+      console.log('testing', url);
       const res = await fetch(url);
       assert.strictEqual(res.status, 404);
     }).timeout(50000);

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -24,21 +24,16 @@ createTargets().forEach((target) => {
       fetchContext.reset();
     });
 
-    it('returns the status of the function', async () => {
-      const url = target.url('/_status_check/healthcheck.json');
+    it('index function rejects wrong prefix', async () => {
+      const url = target.url('/foo');
       const res = await fetch(url);
-      assert.strictEqual(res.status, 200);
-      const json = await res.json();
-      delete json.process;
-      delete json.response_time;
-      // status returns 0.0.0+ci123 for ci versions
-      const version = target.version.startsWith('ci')
-        ? `0.0.0+${target.version}`
-        : target.version;
-      assert.deepStrictEqual(json, {
-        status: 'OK',
-        version,
-      });
+      assert.strictEqual(res.status, 404);
+    }).timeout(50000);
+
+    it('index function rejects wrong requests', async () => {
+      const url = target.url('/domain');
+      const res = await fetch(url);
+      assert.strictEqual(res.status, 400);
     }).timeout(50000);
   });
 });

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -40,11 +40,5 @@ createTargets().forEach((target) => {
         version,
       });
     }).timeout(50000);
-
-    it('invokes the function', async () => {
-      const res = await fetch(target.url('/'));
-      assert.strictEqual(res.status, 200);
-      assert.fail('not ready yet');
-    }).timeout(50000);
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+import assert from 'assert';
+import { isApexDomain } from '../src/utils.js';
+
+describe('Utils Tests', () => {
+  it('isApexDomain returns true for apex domains', async () => {
+    const result = await isApexDomain('example.com');
+    assert.strictEqual(result, true);
+  });
+
+  it('isApexDomain returns false for non-apex domains', async () => {
+    const result = await isApexDomain('www.example.com');
+    assert.strictEqual(result, false);
+  });
+});


### PR DESCRIPTION
This PR adds support for the GET routes and performs DNS validation lookups

- feat: mock implementation
- fix(index): use correct import
- test(index): basic fallback test
- build(deploy): don't use pipeline role
- build(deploy): move to helix-services
- fix(index): use correct prefix
- test(post-deploy): remove failing test
- fix(index): fix path handling and post-deploy test
- test(post-deploy): log test url
- test(post-deploy): fix package name
- fix(index): retry logging
- fix(index): log only using console.log
- feat(index): implement most of GET
- feat(dns): add function to validate a bunch of DNS records and report missing and unexpected errors
- build(package): add lcov reporter
- feat(get): perform dns validation
- test(dns): increase test coverage
- test(dns): test missing record handling
