### PR TITLE
Check SSL Certificate Validity

### DIFF
--- a/src/ssl.js
+++ b/src/ssl.js
@@ -15,7 +15,8 @@ export async function getCertificate(url, rejectUnauthorized = true) {
   const p = new Promise((resolve, reject) => {
     const req = https.request(url, {
       requestCert: true, // we want this, after all
-      rejectUnauthorized, // we check this by default, and try again if it fails
+      rejectUnauthorized, // we check this by default, and try again if it fails,
+      agent: false, // don't use a global agent, so that we don't get TLS session caching
     }, (res) => {
       const cert = res.socket.getPeerCertificate();
       // don't forget to close the connection!

--- a/src/ssl.js
+++ b/src/ssl.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import https from 'https';
+
+export async function getCertificate(url) {
+  const p = new Promise((resolve, reject) => {
+    const req = https.request(url, {
+      requestCert: true, // we want this, after all
+      rejectUnauthorized: false, // we don't care about self-signed certs or expired certs
+    }, (res) => {
+      const cert = res.socket.getPeerCertificate();
+      // don't forget to close the connection!
+      res.socket.end();
+      if (cert) {
+        resolve(cert);
+      } else {
+        reject(new Error('No certificate found'));
+      }
+    });
+    req.on('error', (e) => {
+      reject(e);
+    });
+    req.end();
+  });
+  return p;
+}
+
+/**
+ * Get the validity date of the TLS certificate for a given URL
+ * @param {string} url the URL to check, must start with https://
+ */
+export async function getCertificateValidity(url) {
+  const cert = await getCertificate(url);
+  return new Date(cert.valid_to);
+}

--- a/src/ssl.js
+++ b/src/ssl.js
@@ -41,8 +41,14 @@ export async function getCertificate(url, rejectUnauthorized = true) {
 export async function checkCertificate(url) {
   const cert = await getCertificate(url);
   if (!cert.isValid) {
-    throw new Error('Certificate is not valid');
+    const e = new Error('Certificate is not valid');
+    e.errors = ['Certificate is not valid'];
+    if (cert.valid_to && new Date(cert.valid_to) < new Date()) {
+      e.errors.push(`Certificate expired on ${cert.valid_to}`);
+    }
+    throw e;
   }
+  return new Date(cert.valid_to);
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,8 +28,9 @@ export function isAcmeChallenge(domain) {
   return domain.split('.')[0] === '_acme-challenge';
 }
 
-export function makeResponse(json, type, status = 200, dnserrors = []) {
+export function makeResponse(json, type, status = 200, dnserrors = [], extraHeaders = {}) {
   const headers = {
+    ...extraHeaders,
     'Content-Type': type === 'json' ? 'application/json' : 'text/plain',
   };
   if (dnserrors.length > 0) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,6 +38,8 @@ describe('Index Tests', () => {
     const text = await result.text();
     assert.ok(text.includes('Please create following DNS records:'));
     assert.ok(text.includes('CNAME: cdn.aem.live'), text);
+    assert.ok(result.headers.get('x-remaining-certificate-validity'), 'Missing remaining certificate validity header');
+    assert.ok(Number.parseInt(result.headers.get('x-remaining-certificate-validity'), 10) > 0, 'Remaining certificate validity is not positive');
   });
 
   it('index function handles apex domains', async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,4 +99,24 @@ describe('Index Tests', () => {
       ],
     });
   });
+
+  it('index function handles expired non-apex as JSON', async () => {
+    const result = await main(new Request('https://localhost/helix-services/certificate-provider/ci7641176065/domain/expired.badssl.com', {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }), {
+      logger: console,
+    });
+    assert.strictEqual(result.status, 202);
+    const json = await result.json();
+    assert.deepStrictEqual(json.records, {
+      CNAME: 'cdn.aem.live',
+
+    });
+    assert.equal(json.errors.length, 3, 'Expected 3 errors');
+    assert.equal(json.errors[0], 'Missing CNAME record cdn.aem.live for expired.badssl.com');
+    assert.ok(json.errors[1].includes('Certificate is not valid'));
+    assert.ok(json.errors[2].includes('Certificate expired on '));
+  });
 });

--- a/test/ssl.test.js
+++ b/test/ssl.test.js
@@ -12,12 +12,13 @@
 /* eslint-env mocha */
 
 import assert from 'assert';
-import { getCertificateValidity, getCertificate } from '../src/ssl.js';
+import { getCertificateValidity, checkCertificate } from '../src/ssl.js';
 
 describe.only('Test SSL Utils', () => {
   it('www.example.com has a valid certificate', async () => {
     const valid = await getCertificateValidity('https://www.example.com');
     assert.ok(valid > new Date(), `Certificate is expired on ${valid}`);
+    await checkCertificate('https://www.example.com');
   }).timeout(10000);
 
   it('expired.badssl.com has an expired certificate', async () => {
@@ -34,8 +35,25 @@ describe.only('Test SSL Utils', () => {
     }
   }).timeout(10000);
 
-  it('self-signed.badssl.com has a self-signed certificate', async () => {
-    const cert = await getCertificate('https://self-signed.badssl.com');
-    console.log(cert);
+  it('wrong-host.badssl.com has a no matching host', async () => {
+    try {
+      await checkCertificate('https://wrong-host.badssl.com');
+      assert.fail('Expected an error');
+    } catch (e) {
+      if (e.message === 'Expected an error') {
+        throw e;
+      }
+    }
+  }).timeout(10000);
+
+  it('revoked.badssl.com is revoked', async () => {
+    try {
+      await checkCertificate('https://revoked.badssl.com');
+      assert.fail('Expected an error');
+    } catch (e) {
+      if (e.message === 'Expected an error') {
+        throw e;
+      }
+    }
   }).timeout(10000);
 });

--- a/test/ssl.test.js
+++ b/test/ssl.test.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+
+import assert from 'assert';
+import { getCertificateValidity, getCertificate } from '../src/ssl.js';
+
+describe.only('Test SSL Utils', () => {
+  it('www.example.com has a valid certificate', async () => {
+    const valid = await getCertificateValidity('https://www.example.com');
+    assert.ok(valid > new Date(), `Certificate is expired on ${valid}`);
+  }).timeout(10000);
+
+  it('expired.badssl.com has an expired certificate', async () => {
+    const valid = await getCertificateValidity('https://expired.badssl.com');
+    assert.ok(valid < new Date(), `Certificate is still valid until ${valid}`);
+  }).timeout(10000);
+
+  it('nope.example.com does not resolve', async () => {
+    try {
+      await getCertificateValidity('https://nope.example.com');
+      assert.fail('Expected an error');
+    } catch (e) {
+      assert.ok(e.message.includes('getaddrinfo ENOTFOUND nope.example.com'));
+    }
+  }).timeout(10000);
+
+  it('self-signed.badssl.com has a self-signed certificate', async () => {
+    const cert = await getCertificate('https://self-signed.badssl.com');
+    console.log(cert);
+  }).timeout(10000);
+});

--- a/test/ssl.test.js
+++ b/test/ssl.test.js
@@ -14,7 +14,7 @@
 import assert from 'assert';
 import { getCertificateValidity, checkCertificate } from '../src/ssl.js';
 
-describe.only('Test SSL Utils', () => {
+describe('Test SSL Utils', () => {
   it('www.example.com has a valid certificate', async () => {
     const valid = await getCertificateValidity('https://www.example.com');
     assert.ok(valid > new Date(), `Certificate is expired on ${valid}`);


### PR DESCRIPTION
This PR adds the ability to report TLS certificate validity on GET.
An expired or invalid certificate is not a dealbreaker for ACME validation,
so we won't cause errors for everything, but we report the issues so that 
they can be addressed by the user

- feat(ssl): some utility functions for certificate validation
- fix(ssl): more roubust ssl validation
- feat(index): report on remaining or missing certificate validity
- fix(ssl): do not permit tls session cache
- test(index): validate instructions for expired certificates
